### PR TITLE
Update ruby version to 2.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The files can be downloaded from the following locations:
 
 | Filename | Download URL |
 | -------- | ------------ |
-| ruby-2.1.5.tar.gz | [ruby-lang.org](http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz) |
+| ruby-2.1.6.tar.gz | [ruby-lang.org](http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.gz) |
 | rubygems-2.1.11.tgz | [rubygems.org](http://production.cf.rubygems.org/rubygems/rubygems-2.1.11.tgz) |
 | bundler-1.3.5.gem | [rubygems.org](https://rubygems.org/downloads/bundler-1.3.5.gem) |
 | yaml-0.1.5.tar.gz | [pyyaml.org](http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz) |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The files can be downloaded from the following locations:
 
 | Filename | Download URL |
 | -------- | ------------ |
-| ruby-2.1.6.tar.gz | [ruby-lang.org](http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.gz) |
+| ruby-2.2.2.tar.gz | [ruby-lang.org](http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.gz) |
 | rubygems-2.1.11.tgz | [rubygems.org](http://production.cf.rubygems.org/rubygems/rubygems-2.1.11.tgz) |
 | bundler-1.3.5.gem | [rubygems.org](https://rubygems.org/downloads/bundler-1.3.5.gem) |
 | yaml-0.1.5.tar.gz | [pyyaml.org](http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz) |

--- a/spec
+++ b/spec
@@ -1,7 +1,7 @@
 ---
 name: ruby
 files:
-- ruby/ruby-2.1.5.tar.gz
+- ruby/ruby-2.1.6.tar.gz
 - ruby/rubygems-2.1.11.tgz
 - ruby/bundler-1.3.5.gem
 - ruby/yaml-0.1.5.tar.gz

--- a/spec
+++ b/spec
@@ -1,7 +1,7 @@
 ---
 name: ruby
 files:
-- ruby/ruby-2.1.6.tar.gz
+- ruby/ruby-2.2.2.tar.gz
 - ruby/rubygems-2.1.11.tgz
 - ruby/bundler-1.3.5.gem
 - ruby/yaml-0.1.5.tar.gz


### PR DESCRIPTION
Version 2.1.5 is vulnerable to [CVE-2015-1855](https://www.ruby-lang.org/en/news/2015/04/13/ruby-openssl-hostname-matching-vulnerability)

Signed-off-by: Chris Hedley chris@cghsystems.net
